### PR TITLE
minor fixes

### DIFF
--- a/plugins/RunLogger.py
+++ b/plugins/RunLogger.py
@@ -197,8 +197,13 @@ class RunLogger(SWPlugin.SWPlugin):
         crystal = reward['crystal'] if 'crystal' in reward else 0
         energy = reward['energy'] if 'energy' in reward else 0
 
-        log_entry = "%s,%s,%s,%s,%s,%s,%s," % (time.strftime("%Y-%m-%d %H:%M"),
-                                               config['stage'] if 'stage' in config else 'unknown', win_lost,
+        if 'run-logger-data' in config and wizard_id in config['run-logger-data'] \
+                and 'stage' in config['run-logger-data'][wizard_id]:
+            resp_stage = config['run-logger-data'][wizard_id]['stage']
+        else:
+            resp_stage = 'unknown'
+
+        log_entry = "%s,%s,%s,%s,%s,%s,%s," % (time.strftime("%Y-%m-%d %H:%M"), res_stage, win_lost,
                                                elapsed_time, reward['mana'], crystal, energy)
 
         if 'crate' in reward:

--- a/plugins/RunLogger.py
+++ b/plugins/RunLogger.py
@@ -203,7 +203,7 @@ class RunLogger(SWPlugin.SWPlugin):
         else:
             resp_stage = 'unknown'
 
-        log_entry = "%s,%s,%s,%s,%s,%s,%s," % (time.strftime("%Y-%m-%d %H:%M"), res_stage, win_lost,
+        log_entry = "%s,%s,%s,%s,%s,%s,%s," % (time.strftime("%Y-%m-%d %H:%M"), resp_stage, win_lost,
                                                elapsed_time, reward['mana'], crystal, energy)
 
         if 'crate' in reward:

--- a/plugins/SummonLogger.py
+++ b/plugins/SummonLogger.py
@@ -13,7 +13,9 @@ sources = {
 	5: 'Fire',
 	6: 'Wind',
 	7: 'Legendary',
-	8: 'Exclusive'
+	8: 'Exclusive',
+	9: "Legendary Pieces",
+	10: "Light & Dark Pieces"
 }
 
 def identify_scroll(id):
@@ -42,7 +44,11 @@ class SummonLogger(SWPlugin.SWPlugin):
             if 'item_info' in resp_json:
                 scroll = identify_scroll(resp_json['item_info']['item_master_id'])
             else:
-                scroll = 'Social'
+                mode = req_json['mode']
+                if mode == 3:
+                    scroll = 'Crystal'
+                elif mode == 5:
+                    scroll = 'Social'
             unit_name = monster_name(resp_json['unit_list'][0]['unit_master_id'],'',False)
             attribute = monster_attribute(resp_json['unit_list'][0]['attribute'])
             grade = resp_json['unit_list'][0]['class']
@@ -54,7 +60,7 @@ class SummonLogger(SWPlugin.SWPlugin):
 
             log_entry = "%s,%s,%s,%s,%s*,%s" % (time,scroll,unit_name,attribute,grade,awake)
 
-        filename = "%s-%s" % (resp_json['wizard_info']['wizard_id'], config['log_summon_filename'])
+        filename = "%s-summons.csv" % resp_json['wizard_info']['wizard_id']
         if not os.path.exists(filename):
             log_entry = 'Date,Summon Type,Unit,Attribute,Grade,Awakened\n' + log_entry
 


### PR DESCRIPTION
Summon logger still had parameter from config file, changed to be called wizard_id-summons.csv
Added support for summoning pieces and crystal summons

Run logger was using config['stage'] in final assembly of the log entry, same info is now located at: config['run-logger-data'][wizard_id]['stage']
