### PR TITLE
New SwarfarmLogger plugin

### DIFF
--- a/plugins/SwarfarmLogger.py
+++ b/plugins/SwarfarmLogger.py
@@ -4,90 +4,65 @@ import json
 import os
 import threading
 import urllib
+import urllib2
 
 logger = logging.getLogger("SWProxy")
 
-accepted_commands = [
-    'BattleDungeonResult',
-    'BattleScenarioStart',
-    'BattleScenarioResult',
-    'SummonUnit',
-]
-
 
 class SwarfarmLogger(SWPlugin.SWPlugin):
-    scenario_info = None
+    commands_url = 'https://swarfarm.com/data/log/accepted_commands/'
+    log_url = 'https://swarfarm.com/data/log/upload/'
+    accepted_commands = None
 
     def __init__(self):
         super(SwarfarmLogger, self).__init__()
+        self.plugin_enabled = True
 
         config_name = 'swproxy.config'
         if not os.path.exists(config_name):
             self.config = {}
-            return
+        else:
+            with open(config_name) as f:
+                self.config = json.load(f)
 
-        with open(config_name) as f:
-            self.config = json.load(f)
+        self.plugin_enabled = not self.config.get('disable_swarfarm_logger', False)
+
+        if self.plugin_enabled:
+            # Get the list of accepted commands from the server
+            logger.info('SwarfarmLogger - Retrieving list of accepted log types from SWARFARM...')
+            try:
+                resp = urllib2.urlopen(self.commands_url)
+                self.accepted_commands = json.loads(resp.readline())
+                resp.close()
+            except urllib2.HTTPError:
+                logger.fatal('SwarfarmLogger - Unable to retrieve accepted log types. SWARFARM logging is disabled.')
+                self.plugin_enabled = False
+
 
     def process_request(self, req_json, resp_json):
-        if 'disable_swarfarm_logger' in self.config and self.config['disable_swarfarm_logger']:
-            return
-
-        t = threading.Thread(target=self.process_data, args=(req_json, resp_json))
-        t.start()
-        return
+        if self.plugin_enabled:
+            t = threading.Thread(target=self.process_data, args=(req_json, resp_json))
+            t.start()
 
     def process_data(self, req_json, resp_json):
         command = req_json.get('command')
 
-        if command not in accepted_commands:
-            return
+        if command in self.accepted_commands:
+            accepted_data = self.accepted_commands[command]
+            result_data = {}
 
-        # Store some data about scenarios in case the player fails. Scenario failure req/resp does not contain dungeon data
-        if command == 'BattleScenarioStart':
-            self.scenario_info = {
-                'region_id': req_json.get('region_id'),
-                'difficulty': req_json.get('difficulty'),
-                'stage_no': req_json.get('stage_no'),
-            }
-            return
+            if 'request' in accepted_data:
+                result_data['request'] = {item: req_json.get(item) for item in accepted_data['request']}
 
-        result_data = None
+            if 'response' in accepted_data:
+                result_data['response'] = {item: resp_json.get(item) for item in accepted_data['response']}
 
-        # Generate a trimmed dict with the necessary items from request and response
-        if command in ['BattleDungeonResult', 'BattleScenarioResult']:
-            result_data = {
-                'command': command,
-                'wizard_id': req_json.get('wizard_id'),
-                'tzone': resp_json.get('tzone'),
-                'tvalue': resp_json.get('tvalue'),
-                'dungeon_id': req_json.get('dungeon_id'),
-                'stage_id': req_json.get('stage_id'),
-                'scenario_info': self.scenario_info,
-                'clear_time': req_json['clear_time'],
-                'win_lose': resp_json['win_lose'],
-                'reward': resp_json.get('reward'),
-            }
-        elif command == 'SummonUnit':
-            result_data = {
-                'wizard_id': req_json.get('wizard_id'),
-                'command': command,
-                'tzone': resp_json.get('tzone'),
-                'tvalue': resp_json.get('tvalue'),
-                'mode': req_json.get('mode'),
-                'item_info': resp_json.get('item_info'),
-                'unit_list': resp_json.get('unit_list'),
-            }
-        elif command == 'BattleRiftOfWorldsRaidResult':
-            pass
-
-        if result_data:
-            data = json.dumps(result_data)
-            url = 'https://swarfarm.com/data/log/upload/'
-            resp = urllib.urlopen(url, data=urllib.urlencode({'data': data}))
-            content = resp.readlines()
-            resp.close()
-            if resp.getcode() != 200:
-                logger.warn('SwarfarmLogger - Error: %s' % content)
-
-            self.scenario_info = None
+            if result_data:
+                data = json.dumps(result_data)
+                resp = urllib2.urlopen(self.log_url, data=urllib.urlencode({'data': data}))
+                content = resp.readline()
+                resp.close()
+                if resp.getcode() == 200:
+                    logger.info('SwarfarmLogger - {} logged successfully'.format(command))
+                else:
+                    logger.warn('SwarfarmLogger - Error: %s' % content)

--- a/plugins/SwarfarmLogger.py
+++ b/plugins/SwarfarmLogger.py
@@ -34,10 +34,10 @@ class SwarfarmLogger(SWPlugin.SWPlugin):
                 resp = urllib2.urlopen(self.commands_url)
                 self.accepted_commands = json.loads(resp.readline())
                 resp.close()
+                logger.info('SwarfarmLogger - Looking for the following commands to log:\r\n' + ', '.join(self.accepted_commands.keys()))
             except urllib2.HTTPError:
                 logger.fatal('SwarfarmLogger - Unable to retrieve accepted log types. SWARFARM logging is disabled.')
                 self.plugin_enabled = False
-
 
     def process_request(self, req_json, resp_json):
         if self.plugin_enabled:
@@ -59,10 +59,10 @@ class SwarfarmLogger(SWPlugin.SWPlugin):
 
             if result_data:
                 data = json.dumps(result_data)
-                resp = urllib2.urlopen(self.log_url, data=urllib.urlencode({'data': data}))
-                content = resp.readline()
-                resp.close()
-                if resp.getcode() == 200:
-                    logger.info('SwarfarmLogger - {} logged successfully'.format(command))
+                try:
+                    resp = urllib2.urlopen(self.log_url, data=urllib.urlencode({'data': data}))
+                except urllib2.HTTPError as e:
+                    logger.warn('SwarfarmLogger - Error: {}'.format(e.readline()))
                 else:
-                    logger.warn('SwarfarmLogger - Error: %s' % content)
+                    resp.close()
+                    logger.info('SwarfarmLogger - {} logged successfully'.format(command))


### PR DESCRIPTION
I wrote a new plugin for logging data to swarfarm. It retrieves a list of accepted API commands and the data required from the server on startup. This allows creating new log types (shop refreshes, world boss, etc) without requiring an update to the SWProxy plugin, along with quicker bug fixes when issues appear. 
